### PR TITLE
Fix sanitizer trace parsing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ package_dir =
     = src
 include_package_data = True
 install_requires =
-    FuzzManager
+    FuzzManager>=0.6.0
     boto
     fasteners
     psutil


### PR DESCRIPTION
Index mismatch errors are now allowed, so long as the log before the error parses into a valid CrashInfo.