### PR TITLE
Add config.sh and upload all corpus files to queue

### DIFF
--- a/src/guided_fuzzing_daemon/nyx.py
+++ b/src/guided_fuzzing_daemon/nyx.py
@@ -401,7 +401,10 @@ def nyx_main(
                 and last_queue_upload < time() - QUEUE_UPLOAD_PERIOD
             ):
                 assert s3m is not None
-                s3m.upload_afl_queue_dir(opts.corpus_out / "0")
+                s3m.upload_afl_queue_dir(
+                    opts.corpus_out / "0",
+                    opts.sharedir / "config.sh",
+                )
                 last_queue_upload = time()
 
             # Calculate stats
@@ -442,7 +445,7 @@ def nyx_main(
         log_tee.close()
 
         if s3m and opts.s3_queue_upload:
-            s3m.upload_afl_queue_dir(opts.corpus_out / "0")
+            s3m.upload_afl_queue_dir(opts.corpus_out / "0", opts.sharedir / "config.sh")
 
         # final stats
         if opts.stats:

--- a/src/guided_fuzzing_daemon/nyx.py
+++ b/src/guided_fuzzing_daemon/nyx.py
@@ -404,6 +404,7 @@ def nyx_main(
                 s3m.upload_afl_queue_dir(
                     opts.corpus_out / "0",
                     opts.sharedir / "config.sh",
+                    include_sync=True,
                 )
                 last_queue_upload = time()
 
@@ -445,7 +446,9 @@ def nyx_main(
         log_tee.close()
 
         if s3m and opts.s3_queue_upload:
-            s3m.upload_afl_queue_dir(opts.corpus_out / "0", opts.sharedir / "config.sh")
+            s3m.upload_afl_queue_dir(
+                opts.corpus_out / "0", opts.sharedir / "config.sh", include_sync=True
+            )
 
         # final stats
         if opts.stats:

--- a/src/guided_fuzzing_daemon/s3.py
+++ b/src/guided_fuzzing_daemon/s3.py
@@ -646,7 +646,9 @@ def s3_main(opts: Namespace) -> int:
                 "directories.",
                 file=sys.stderr,
             )
-            return 0
+            # allow nyx to pass if config.sh already exists in sharedir
+            if not (opts.mode == "nyx" and (opts.sharedir / cmdline_file).is_file()):
+                return 0
 
         if opts.build:
             build_path = Path(opts.build)
@@ -704,7 +706,8 @@ def s3_main(opts: Namespace) -> int:
             if opts.mode == "nyx":
                 assert opts.aflbindir.is_dir()
                 assert opts.sharedir.is_dir()
-                shutil.copy(cmdline_file, opts.sharedir)
+                if not (opts.sharedir / cmdline_file).is_file():
+                    shutil.copy(cmdline_file, opts.sharedir)
 
                 # Run afl-cmin
                 afl_cmin = Path(opts.aflbindir) / "afl-cmin"

--- a/src/guided_fuzzing_daemon/s3.py
+++ b/src/guided_fuzzing_daemon/s3.py
@@ -158,6 +158,7 @@ class S3Manager:
         base_path: Path,
         cmdline_path: Path,
         new_cov_only: bool = True,
+        include_sync: bool = False,
     ) -> None:
         """Synchronize the queue directory of the specified AFL base directory
         to the specified S3 bucket. This method only uploads files that don't
@@ -167,6 +168,7 @@ class S3Manager:
             base_path: AFL base directory
             cmdline_path: cmdline file (or other file) to be included in queues
             new_cov_only: Only upload files that have new coverage
+            include_sync: Upload files obtained from other local queues
         """
         queue_path = base_path / "queue"
         queue_files = []
@@ -186,7 +188,7 @@ class S3Manager:
 
             # Ignore files that have been obtained from other local queues
             # to avoid duplicate uploading
-            if ",sync:" in queue_file.name:
+            if not include_sync and ",sync:" in queue_file.name:
                 continue
 
             queue_files.append(queue_file.name)

--- a/tests/test_nyx.py
+++ b/tests/test_nyx.py
@@ -175,7 +175,9 @@ def test_nyx_02(mocker, nyx):
 
     # check that upload is called once in the loop, once in finally
     assert nyx.s3m.upload_afl_queue_dir.call_count == 2
-    assert nyx.s3m.upload_afl_queue_dir.call_args == mocker.call(nyx.corpus_out / "0")
+    assert nyx.s3m.upload_afl_queue_dir.call_args == mocker.call(
+        nyx.corpus_out / "0", nyx.sharedir / "config.sh"
+    )
 
 
 def test_nyx_03a(nyx):

--- a/tests/test_nyx.py
+++ b/tests/test_nyx.py
@@ -176,7 +176,7 @@ def test_nyx_02(mocker, nyx):
     # check that upload is called once in the loop, once in finally
     assert nyx.s3m.upload_afl_queue_dir.call_count == 2
     assert nyx.s3m.upload_afl_queue_dir.call_args == mocker.call(
-        nyx.corpus_out / "0", nyx.sharedir / "config.sh"
+        nyx.corpus_out / "0", nyx.sharedir / "config.sh", include_sync=True
     )
 
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -84,12 +84,14 @@ def test_s3_main_03(mocker, tmp_path):
     args.s3_corpus_refresh = tmp_path
     args.s3_list_projects = False
     args.build = None
+    args.sharedir = tmp_path / "sharedir"
+    (tmp_path / "sharedir").mkdir()
     assert s3_main(args) == 0
     assert mgr.return_value.method_calls == [
         mocker.call.clean_queue_dirs(),
         mocker.call.download_queue_dirs(tmp_path),
     ]
-    (tmp_path / "cmdline").write_text("build/firefox")
+    (tmp_path / "config.sh").write_text("build/firefox")
     (tmp_path / "build").mkdir()
 
     def fake_run(*_args, **_kwds):


### PR DESCRIPTION
- Nyx uses `config.sh` to set `NYX_FUZZER` and other required env variables. This is required for S3 corpus refresh, so we should be storing that in the S3 corpus directory and using it during corpus refresh.
- AFL upload function used to ignore files with `sync` in the filename, but for AFL++ we only upload the `-M` corpus. We do want `sync` files if they were pulled from `-S` instances. This matches [recommendations in AFL++ docs](https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/fuzzing_in_depth.md#d-using-multiple-machines-for-fuzzing).

