### PR TITLE
AFL++ -F is only valid after -M

### DIFF
--- a/src/guided_fuzzing_daemon/nyx.py
+++ b/src/guided_fuzzing_daemon/nyx.py
@@ -251,9 +251,9 @@ def nyx_main(
                         cmd = ["-M", "0"]
                         if opts.nyx_async_corpus:
                             cmd.extend(("-F", str(opts.corpus_in)))
-                    if opts.nyx_add_corpus:
-                        for additional_corpus in opts.nyx_add_corpus:
-                            cmd.extend(("-F", str(additional_corpus)))
+                        if opts.nyx_add_corpus:
+                            for additional_corpus in opts.nyx_add_corpus:
+                                cmd.extend(("-F", str(additional_corpus)))
 
                     # environment settings that apply to this instance
                     this_env = envs[idx].copy()

--- a/tests/test_nyx.py
+++ b/tests/test_nyx.py
@@ -662,4 +662,4 @@ def test_nyx_12(mocker, nyx, tmp_path):
     assert len(popen_calls) == 2
     main, sec = popen_calls
     assert set(_get_path_args("-F", main.args[0])) == {corpus_add}
-    assert set(_get_path_args("-F", sec.args[0])) == {corpus_add}
+    assert set(_get_path_args("-F", sec.args[0])) == set()


### PR DESCRIPTION
```
afl-fuzz++4.09a based on afl by Michal Zalewski and a large online community

[-] PROGRAM ABORT : Option -F can only be specified after the -M option for the main fuzzer of a fuzzing campaign
         Location : main(), src/afl-fuzz.c:815
```