### PR TITLE
`project` should be `None` when cloud storage is not used

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -45,10 +45,6 @@ tasks:
         - tox; tox -e codecov
       jobs:
         include:
-          - name: tests python 3.8
-            version: "3.8"
-            env:
-              TOXENV: py38,lint
           - name: tests python 3.9
             version: "3.9"
             env:
@@ -61,6 +57,10 @@ tasks:
             version: "3.11"
             env:
               TOXENV: py311,lint
+          - name: tests python 3.12
+            version: "3.12"
+            env:
+              TOXENV: py312,lint
 
   in:
     $if: >

--- a/src/guided_fuzzing_daemon/storage.py
+++ b/src/guided_fuzzing_daemon/storage.py
@@ -340,16 +340,20 @@ class GoogleCloudStorage(CloudStorageProvider):
 class CorpusSyncer:
     provider: CloudStorageProvider
     corpus: Corpus
-    project: PurePosixPath
+    project: PurePosixPath | None
 
     def __init__(
-        self, provider: CloudStorageProvider, corpus: Corpus, project: str
+        self, provider: CloudStorageProvider, corpus: Corpus, project: str | None
     ) -> None:
         self.provider = provider
         self.corpus = corpus
-        self.project = PurePosixPath(project)
+        if project is None:
+            self.project = None
+        else:
+            self.project = PurePosixPath(project)
 
     def download_corpus(self, random_subset_size: int | None = None) -> int:
+        assert self.project is not None
         start = perf_counter()
         with Executor() as executor:
             prefix = self.project / "corpus"
@@ -379,6 +383,7 @@ class CorpusSyncer:
         return downloaded
 
     def upload_corpus(self, delete_existing: bool = False) -> None:
+        assert self.project is not None
         start = perf_counter()
         with Executor() as executor:
             prefix = self.project / "corpus"
@@ -419,6 +424,7 @@ class CorpusSyncer:
             )
 
     def upload_queue(self, skip_hashes: Iterable[str]) -> None:
+        assert self.project is not None
         start = perf_counter()
         # get list of files existing
         prefix = self.project / "queues" / self.corpus.uuid
@@ -454,6 +460,7 @@ class CorpusSyncer:
         )
 
     def delete_queues(self) -> None:
+        assert self.project is not None
         start = perf_counter()
         # get list of queue files to delete
         prefix = self.project / "queues"
@@ -466,6 +473,7 @@ class CorpusSyncer:
         )
 
     def download_queues(self) -> dict[str, int]:
+        assert self.project is not None
         start = perf_counter()
         # download all queue files to corpus
         status_data = {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py3{8,9,10,11,12}
+envlist = lint,py3{9,10,11,12}
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 


### PR DESCRIPTION
This was hit when running locally with no storage options.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/user/mozdira/fuzzing/guided-fuzzing-daemon/src/guided_fuzzing_daemon/__main__.py", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/mozdira/fuzzing/guided-fuzzing-daemon/src/guided_fuzzing_daemon/main.py", line 124, in main
    return libfuzzer_main(opts, collector, storage)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mozdira/fuzzing/guided-fuzzing-daemon/src/guided_fuzzing_daemon/libfuzzer.py", line 428, in libfuzzer_main
    corpus_syncer = CorpusSyncer(storage, Corpus(corpus_dir), opts.project)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mozdira/fuzzing/guided-fuzzing-daemon/src/guided_fuzzing_daemon/storage.py", line 350, in __init__
    self.project = PurePosixPath(project)
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pathlib.py", line 373, in __init__
    raise TypeError(
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```