### PR TITLE
Use zip for corpus upload & preserve extensions

### DIFF
--- a/src/guided_fuzzing_daemon/args.py
+++ b/src/guided_fuzzing_daemon/args.py
@@ -199,10 +199,11 @@ def parse_args(argv: list[str] | None = None) -> Namespace:
         help="Use cloud storage to upload a test corpus for the specified project",
         metavar="DIR",
     )
+    # deprecated (default)
     storage_group.add_argument(
         "--corpus-replace",
         action="store_true",
-        help="In conjunction with --corpus-upload, deletes all other remote test files",
+        help=SUPPRESS,
     )
     storage_group.add_argument(
         "--corpus-refresh",
@@ -488,6 +489,9 @@ def parse_args(argv: list[str] | None = None) -> Namespace:
         LOG.warning("--afl-timeout is deprecated, use --timeout instead")
         assert opts.timeout is None
         opts.timeout = opts.afl_timeout
+
+    if opts.corpus_replace:
+        LOG.warning("--corpus-replace is deprecated (now default behavior)")
 
     if opts.mode == "nyx":
         if opts.rargs:

--- a/src/guided_fuzzing_daemon/fuzzilli.py
+++ b/src/guided_fuzzing_daemon/fuzzilli.py
@@ -176,7 +176,7 @@ def main(
     assert binary.is_file()
 
     if opts.corpus_refresh:
-        with CorpusRefreshContext(opts, storage, subdir="corpus") as merger:
+        with CorpusRefreshContext(opts, storage, "corpus", ".fzil") as merger:
             env = os.environ.copy()
             env["LD_LIBRARY_PATH"] = str(binary.parent)
 
@@ -217,7 +217,7 @@ def main(
 
     assert opts.corpus_out
     corpus_syncer = CorpusSyncer(
-        storage, Corpus(opts.corpus_out / "corpus"), opts.project
+        storage, Corpus(opts.corpus_out / "corpus"), opts.project, ".fzil"
     )
 
     base_cfg = ProgramConfiguration.fromBinary(binary)

--- a/src/guided_fuzzing_daemon/main.py
+++ b/src/guided_fuzzing_daemon/main.py
@@ -85,7 +85,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if opts.list_projects:
-        for project in storage.iter_projects(opts.project or ""):
+        for project in sorted(storage.iter_projects(opts.project or "")):
             LOG.info(project)
         return 0
 

--- a/src/guided_fuzzing_daemon/main.py
+++ b/src/guided_fuzzing_daemon/main.py
@@ -81,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if opts.corpus_upload:
         syncer = CorpusSyncer(storage, Corpus(opts.corpus_upload), opts.project)
-        syncer.upload_corpus(opts.corpus_replace)
+        syncer.upload_corpus()
         return 0
 
     if opts.list_projects:

--- a/src/guided_fuzzing_daemon/storage.py
+++ b/src/guided_fuzzing_daemon/storage.py
@@ -388,7 +388,7 @@ class CorpusSyncer:
         )
         return downloaded
 
-    def upload_corpus(self, delete_existing: bool = False) -> None:
+    def upload_corpus(self) -> None:
         assert self.project is not None
         start = perf_counter()
         with Executor() as executor:
@@ -409,25 +409,16 @@ class CorpusSyncer:
                     uploaded += 1
 
         # delete files that no longer exist in the local corpus
-        if delete_existing:
-            deleted = len(existing)
-            self.provider.delete(tuple(existing.values()))
-            LOG.info(
-                "upload_corpus() -> before=%d, new=%d, deleted=%d, after=%d (%.03fs)",
-                old_corpus_size,
-                uploaded,
-                deleted,
-                uploaded + old_corpus_size - deleted,
-                perf_counter() - start,
-            )
-        else:
-            LOG.info(
-                "upload_corpus() -> before=%d, new=%d, after=%d (%.03fs)",
-                old_corpus_size,
-                uploaded,
-                uploaded + old_corpus_size,
-                perf_counter() - start,
-            )
+        deleted = len(existing)
+        self.provider.delete(tuple(existing.values()))
+        LOG.info(
+            "upload_corpus() -> before=%d, new=%d, deleted=%d, after=%d (%.03fs)",
+            old_corpus_size,
+            uploaded,
+            deleted,
+            uploaded + old_corpus_size - deleted,
+            perf_counter() - start,
+        )
 
     def upload_queue(self, skip_hashes: Iterable[str]) -> None:
         assert self.project is not None
@@ -634,7 +625,7 @@ class CorpusRefreshContext:
         corpus_uploader = CorpusSyncer(
             self.storage, Corpus(updated_tests_dir), self.project
         )
-        corpus_uploader.upload_corpus(delete_existing=True)
+        corpus_uploader.upload_corpus()
         for extra in self.extra_files:
             remote_obj = self.storage[
                 PurePosixPath(self.project) / "corpus" / extra.name

--- a/src/guided_fuzzing_daemon/storage.py
+++ b/src/guided_fuzzing_daemon/storage.py
@@ -424,9 +424,8 @@ class CorpusSyncer:
         to_delete = {
             file.path.name: file for file in self.provider.iter(self.project / "corpus")
         }
-        # remove corpus.zip, it will be overwritten on success, or re-added to this
-        # dict if the corpus is empty
-        corpus_zip_exists = to_delete.pop("corpus.zip", None)
+        # remove corpus.zip, it will be overwritten on success
+        to_delete.pop("corpus.zip", None)
 
         with TempPath() as tmpd:
             corpus_zip_remote = self.provider[self.project / "corpus.zip"]
@@ -441,9 +440,9 @@ class CorpusSyncer:
             if uploaded:
                 corpus_zip_remote.upload_from_file(corpus_zip_local)
                 LOG.info("Uploaded ZIP: %s", corpus_zip_local.name)
-            elif corpus_zip_exists is not None:
-                to_delete["corpus.zip"] = corpus_zip_exists
-                LOG.warning("Corpus is empty! Deleting corpus.zip")
+            else:
+                LOG.warning("Corpus is empty! Not deleting existing corpus")
+                to_delete.clear()
 
         self.provider.delete(to_delete.values())
 

--- a/tests/test_afl.py
+++ b/tests/test_afl.py
@@ -650,7 +650,7 @@ def test_afl_refresh_02(afl, mocker, tmp_path):
     assert syncer.return_value.method_calls == [
         mocker.call.download_corpus(),
         mocker.call.download_queues(),
-        mocker.call.upload_corpus(delete_existing=True),
+        mocker.call.upload_corpus(),
         mocker.call.delete_queues(),
     ]
     assert stats.return_value.write_file.call_count == 2

--- a/tests/test_fuzzilli.py
+++ b/tests/test_fuzzilli.py
@@ -417,7 +417,7 @@ def test_fuzzilli_09(fuzzilli, mocker, tmp_path):
     assert syncer.return_value.method_calls == [
         mocker.call.download_corpus(),
         mocker.call.download_queues(),
-        mocker.call.upload_corpus(delete_existing=True),
+        mocker.call.upload_corpus(),
         mocker.call.delete_queues(),
     ]
     assert stats.return_value.write_file.call_count == 2

--- a/tests/test_libfuzzer.py
+++ b/tests/test_libfuzzer.py
@@ -456,7 +456,7 @@ def test_libfuzzer_refresh_01(libf, mocker, tmp_path):
     assert syncer.return_value.method_calls == [
         mocker.call.download_corpus(),
         mocker.call.download_queues(),
-        mocker.call.upload_corpus(delete_existing=True),
+        mocker.call.upload_corpus(),
         mocker.call.delete_queues(),
     ]
     assert stats.return_value.write_file.call_count == 2

--- a/tests/test_nyx.py
+++ b/tests/test_nyx.py
@@ -633,7 +633,7 @@ def test_nyx_refresh_02(mocker, nyx, tmp_path):
     assert syncer.return_value.method_calls == [
         mocker.call.download_corpus(),
         mocker.call.download_queues(),
-        mocker.call.upload_corpus(delete_existing=True),
+        mocker.call.upload_corpus(),
         mocker.call.delete_queues(),
     ]
     assert stats.return_value.write_file.call_count == 2

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -744,8 +744,7 @@ def test_syncer_02(mocker, tmp_path):
     assert f3.method_calls == []
 
 
-@pytest.mark.parametrize("delete_existing", (True, False))
-def test_syncer_03(delete_existing, mocker, tmp_path):
+def test_syncer_03(mocker, tmp_path):
     """test upload_corpus()"""
     # pylint: disable=unnecessary-dunder-call
     storage = mocker.MagicMock(spec=CloudStorageProvider)
@@ -759,10 +758,9 @@ def test_syncer_03(delete_existing, mocker, tmp_path):
     f2 = mocker.Mock(spec=CloudStorageFile, path=PurePosixPath("t_proj/corpus/62"))
     storage.iter.side_effect = [(f1, f2)]
     syncer = CorpusSyncer(storage, corpus, "t_proj")
-    syncer.upload_corpus(delete_existing=delete_existing)
+    syncer.upload_corpus()
     assert storage.mock_calls.pop(0) == mocker.call.iter(PurePosixPath("t_proj/corpus"))
-    if delete_existing:
-        assert storage.mock_calls.pop() == mocker.call.delete((f1,))
+    assert storage.mock_calls.pop() == mocker.call.delete((f1,))
 
     expected_paths = {
         PurePosixPath("t_proj/corpus/63"): l3,


### PR DESCRIPTION
Our corpora become too large for unstable targets, and S3/GCS are very slow.
Fuzzilli needs the .fzil extension to remain on the testcase.