### PR TITLE
fix(gcs): ignore folders returned by "list_blobs"

### DIFF
--- a/src/guided_fuzzing_daemon/storage.py
+++ b/src/guided_fuzzing_daemon/storage.py
@@ -354,6 +354,8 @@ class GoogleCloudStorage(CloudStorageProvider):
 
     def iter(self, prefix: PurePosixPath) -> Iterator[CloudStorageFile]:
         for blob in self.bucket.list_blobs(prefix=f"{prefix}/"):
+            if blob.name.endswith("/"):
+                continue
             yield GCSFile(PurePosixPath(blob.name), blob.updated, blob.size, self)
 
     def iter_projects(self, prefix: str = "") -> Iterable[str]:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -599,9 +599,11 @@ def test_googlecloudstorage_01(gcs, mocker):
 
 def test_googlecloudstorage_02(gcs, mocker):
     """test GoogleCloudStorage.iter()"""
-    mock_blob = mocker.MagicMock(updated=datetime(2023, 8, 23))
-    mock_blob.name = "test_file.txt"
-    gcs.bucket.list_blobs.return_value = [mock_blob]
+    mock_blob1 = mocker.MagicMock(updated=datetime(2023, 8, 23))
+    mock_blob1.name = "test_file.txt"
+    mock_blob2 = mocker.MagicMock(updated=datetime(2023, 8, 23))
+    mock_blob2.name = "/"
+    gcs.bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
 
     files = list(gcs.iter(PurePosixPath("prefix")))
 


### PR DESCRIPTION
Folders don't exist in GCS, but they are simulated on the Cloud Console using 0-byte files that end in '/'. We should ignore these when listing blobs.